### PR TITLE
Make API base URL configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+backend/venv/
+**/__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # TTU
+
+## Configuration
+
+The frontend uses the `REACT_APP_API_URL` environment variable to determine the
+base URL for API requests. If not set, it defaults to `http://127.0.0.1:8000/api`
+during development.

--- a/dms-frontend/README.md
+++ b/dms-frontend/README.md
@@ -2,6 +2,11 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+### API URL
+
+The frontend reads the API base URL from the `REACT_APP_API_URL` environment
+variable. During development it defaults to `http://127.0.0.1:8000/api`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/dms-frontend/src/services/api.js
+++ b/dms-frontend/src/services/api.js
@@ -1,7 +1,10 @@
 import axios from 'axios';
 
+// Use REACT_APP_API_URL if available, otherwise default to local development server
+const baseURL = process.env.REACT_APP_API_URL || 'http://127.0.0.1:8000/api';
+
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:8000/api', // your Django server URL
+  baseURL,
 });
 
 export default API;


### PR DESCRIPTION
## Summary
- allow configuring API base URL via `REACT_APP_API_URL`
- document the env var in both READMEs
- add a root `.gitignore`

## Testing
- `npm test --silent --maxWorkers=2` *(fails: Cannot find module 'react-router-dom')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6845aa8565508329939844bfeb3591c0